### PR TITLE
Refactoring input and removing tensorinfo_map

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -131,20 +131,14 @@ pub struct TensorAnalysis {
     pub blacklist_nodes: HashSet<Mdl>,
     /// Newly added nodes by order
     pub newly_added: Vec<Mdl>,
-    /// Tracking TensorInfo for C++-originating ops
-    pub tensorinfo_map: HashMap<Id, TensorInfo>,
     pub blackbox_cpp_num_to_shape: HashMap<i32, TensorInfo>,
 }
 
 impl<'a> TensorAnalysis {
-    pub fn new(
-        tensorinfo_map: &HashMap<Id, TensorInfo>,
-        blackbox_cpp_num_to_shape: &HashMap<i32, TensorInfo>,
-    ) -> Self {
+    pub fn new(blackbox_cpp_num_to_shape: &HashMap<i32, TensorInfo>) -> Self {
         TensorAnalysis {
             blacklist_nodes: HashSet::<Mdl>::new(),
             newly_added: Vec::<Mdl>::new(),
-            tensorinfo_map: tensorinfo_map.clone(),
             blackbox_cpp_num_to_shape: blackbox_cpp_num_to_shape.clone(),
         }
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -26,7 +26,7 @@ impl CostFunction<Mdl> for TensorCost<'_> {
 pub struct CostModel {}
 
 impl CostModel {
-    pub fn new(/* tensorinfo_map: &'a HashMap<Id, TensorInfo> */) -> Self {
+    pub fn new() -> Self {
         Self {}
     }
 


### PR DESCRIPTION
We should also merge the `no_tensorinfo` branch and get rid of this struct entirely